### PR TITLE
Fail monitor-progress example on error and copy test data to engine in CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
             echo "Will start Qlik Associative Engine version '$ENGINE_VERSION'"
             ENGINE_CONTAINER_ID=$(docker run -d qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
             ENGINE_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ENGINE_CONTAINER_ID)
+            docker cp /go/src/github.com/qlik-oss/enigma-go/examples/reload/monitor-progress/testdata/ $ENGINE_CONTAINER_ID:/testdata
             TEST_CONTAINER_ID=$(docker run -d golang:1.9-alpine tail -f /dev/null)
             docker cp . $TEST_CONTAINER_ID:/go
             docker exec $TEST_CONTAINER_ID /bin/sh -c 'apk update && apk add --no-cache socat bash'


### PR DESCRIPTION
The `monitor-progress` example did not fail even if the reload was unsuccessful. Added panic if err in the example and also copied the testdata needed in Circle CI. 
