### PR TITLE
Update flag for go get in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Examples of use may be building your own analytics tools, back-end services, or 
 ---
 ## Installation
 
+```bash
 go get -u github.com/qlik-oss/enigma-go
+```
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Examples of use may be building your own analytics tools, back-end services, or 
 ---
 ## Installation
 
-go get -U github.com/qlik-oss/enigma-go
+go get -u github.com/qlik-oss/enigma-go
 
 ## Getting started
 


### PR DESCRIPTION
The documentation for installing the package used an incorrect flag `-U`. It should be lowercase.