### PR TITLE
Add script for generating enigma-go based on specific JSON-RPC API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Examples of use may be building your own analytics tools, back-end services, or 
 - [API documentation](https://godoc.org/github.com/qlik-oss/enigma-go)
 - [Contributing](./.github/CONTRIBUTING.md#contributing-to-enigma-go)
 - [Runnable examples](./examples/README.md)
+- [Generating from schema](./schema/README.md)
 
 ---
+
 ## Installation
 
 go get -U github.com/qlik-oss/enigma-go

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,2 +1,10 @@
 # Schema Generator
-Generates the API based on a json specification
+
+This folder contains a script for generating enigma-go based on a specific version of Qlik Analytics Engine.
+The version to be used must be one of the published versions of the Qlik Analytics Engine, see [here](https://hub.docker.com/r/qlikcore/engine/tags/).
+
+If a version is not specified the script will default to the latest published version.
+
+```bash
+ENGINE_VERSION=12.160.6 ./schema/generate.sh
+```

--- a/schema/README.md
+++ b/schema/README.md
@@ -3,8 +3,14 @@
 This folder contains a script for generating enigma-go based on a specific version of Qlik Analytics Engine.
 The version to be used must be one of the published versions of the Qlik Analytics Engine, see [here](https://hub.docker.com/r/qlikcore/engine/tags/).
 
+Please note that to be able to generate enigma-go you will need to accept the [EULA](https://qlikcore.com/beta/).
+
+```bash
+ACCEPT_EULA=<yes/no> ENGINE_VERSION=12.160.6 ./schema/generate.sh
+```
+
 If a version is not specified the script will default to the latest published version.
 
 ```bash
-ENGINE_VERSION=12.160.6 ./schema/generate.sh
+ACCEPT_EULA=<yes/no> ./schema/generate.sh
 ```

--- a/schema/cron.sh
+++ b/schema/cron.sh
@@ -42,7 +42,7 @@ if [ ! -z "$local_changes" ]; then
   git push -u origin $branch_name
   curl -u none:$GH_TOKEN https://api.github.com/repos/qlik-oss/enigma-go/pulls --request POST --data "{
         \"title\": \"Automated: Generated enigma-go based on new JSON-RPC API\",
-        \"body\": \"Hello! This is an automated pull request.\n\nI have generated a new enigma-go based on the JSON-RPC API for Qlik Analytics Engine version $ENGINE_VERSION.\",
+        \"body\": \"Hello! This is an automated pull request.\n\nI have generated a new enigma-go based on the JSON-RPC API for Qlik Analytics Engine.\",
         \"head\": \"$branch_name\",
         \"base\": \"master\"
       }"

--- a/schema/cron.sh
+++ b/schema/cron.sh
@@ -32,12 +32,12 @@ fi
 # Generate enigma-go based on latest published Qlik Analytics Engine image
 ./schema/generate.sh
 
-# If there are changes open a pull request
-local_changes=$(git --no-pager diff -w)
+# If there are changes to qix_generated.go then open a pull request
+local_changes=$(git ls-files qix_generated.go -m)
 
 if [ ! -z "$local_changes" ]; then
   git checkout -b $branch_name
-  git add .
+  git add qix_generated.go
   git commit -m "Automated: Generated enigma-go based on new JSON-RPC API"
   git push -u origin $branch_name
   curl -u none:$GH_TOKEN https://api.github.com/repos/qlik-oss/enigma-go/pulls --request POST --data "{

--- a/schema/cron.sh
+++ b/schema/cron.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+cd $(dirname "$0")
+
+repo_folder=enigma-go-repo
+branch_name=automated-bump-engine-schema
+
+if [ -z "$GH_TOKEN" ]; then
+  echo "Missing GH_TOKEN variable."
+  exit 1
+fi
+
+rm -rf $repo_folder
+mkdir $repo_folder
+cd $repo_folder
+
+git init
+git remote add origin git@github.com:qlik-oss/enigma-go.git
+git config core.fileMode false
+git config core.autocrlf false
+git config core.safecrlf false
+git fetch
+git checkout master
+
+existing_branch=$(git branch -r | grep -i "$branch_name")
+
+if [ ! -z "$existing_branch" ]; then
+  echo "There is already a bump branch, please remove/merge it and run this tool again."
+  exit 1
+fi
+
+# Generate enigma-go based on latest published Qlik Analytics Engine image
+./schema/generate.sh
+
+# If there are changes open a pull request
+local_changes=$(git --no-pager diff -w)
+
+if [ ! -z "$local_changes" ]; then
+  git checkout -b $branch_name
+  git add .
+  git commit -m "Automated: Generated enigma-go based on new JSON-RPC API"
+  git push -u origin $branch_name
+  curl -u none:$GH_TOKEN https://api.github.com/repos/qlik-oss/enigma-go/pulls --request POST --data "{
+        \"title\": \"Automated: Generated enigma-go based on new JSON-RPC API\",
+        \"body\": \"Hello! This is an automated pull request.\n\nI have generated a new enigma-go based on the JSON-RPC API for Qlik Analytics Engine version $ENGINE_VERSION.\",
+        \"head\": \"$branch_name\",
+        \"base\": \"master\"
+      }"
+else
+  echo "No changes to schema."
+fi

--- a/schema/generate.go
+++ b/schema/generate.go
@@ -231,7 +231,12 @@ func createArrayTypesMap(schema *Schema) map[string]bool {
 }
 
 func loadSchemaFile() (*Schema, error) {
-	rawSchemaFile, err := ioutil.ReadFile("./schema/schema.json")
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	rawSchemaFile, err := ioutil.ReadFile(pwd + "/schema.json")
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -636,10 +641,16 @@ func main() {
 
 	schema, err := loadSchemaFile()
 
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	expandGenericObjectWithLayouts(schema)
 	removeRedundantNxInfo(schema)
 	// Start generating the go file
-	out, err := os.Create("./qix_generated.go")
+	out, err := os.Create(pwd + "/../qix_generated.go")
 	defer out.Close()
 	if err != nil {
 		fmt.Println(err.Error())
@@ -723,4 +734,3 @@ func main() {
 		}
 	}
 }
-

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -2,19 +2,25 @@
 
 cd $(dirname "$0")
 
+# Check that the EULA has been accepted
+if [[ $ACCEPT_EULA != "yes" ]]; then
+    echo "The EULA for Qlik Analytics Engine was not accepted. Please check the README for instructions on how to accept the EULA"
+    exit 1
+fi
+
 # Fetch latest published Qlik Analytics Engine version on dockerhub if not specified
 if [ -z $ENGINE_VERSION ]; then
     ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
-    echo "Using latest Engine version is $ENGINE_VERSION"
+    echo "Using latest Engine version $ENGINE_VERSION"
 fi
 
 # Retrieve the JSON-RPC API from Qlik Analytics Engines REST API
 CONTAINER_ID=$(docker run -d -p 9076:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
 RETRIES=0
 while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
-  JSON_RPC_API=$(curl -fs localhost:9076/jsonrpc-api)
-  sleep 2
-  RETRIES=$((RETRIES + 1 ))
+    JSON_RPC_API=$(curl -fs localhost:9076/jsonrpc-api)
+    sleep 2
+    RETRIES=$((RETRIES + 1 ))
 done
 docker kill $CONTAINER_ID
 

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -15,7 +15,7 @@ if [ -z $ENGINE_VERSION ]; then
 fi
 
 # Retrieve the JSON-RPC API from Qlik Analytics Engines REST API
-CONTAINER_ID=$(docker run -d -p 9076:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
+CONTAINER_ID=$(docker run -d -p 9076:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=$ACCEPT_EULA)
 RETRIES=0
 while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
     JSON_RPC_API=$(curl -fs localhost:9076/jsonrpc-api)

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cd $(dirname "$0")
+
+# Fetch latest published Qlik Analytics Engine version on dockerhub if not specified
+if [ -z $ENGINE_VERSION ]; then
+    ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
+    echo "Using latest Engine version is $ENGINE_VERSION"
+fi
+
+# Retrieve the JSON RPC API from Qlik Analytics Engines REST API
+CONTAINER_ID=$(docker run -d -p 9076:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
+RETRIES=0
+while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
+  JSON_RPC_API=$(curl -fs localhost:9076/jsonrpc-api)
+  sleep 2
+  RETRIES=$((RETRIES + 1 ))
+done
+
+# Generate enigma-go based on schema
+if [[ $JSON_RPC_API != "" ]]; then
+    echo "Generating enigma-go based on JSON RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
+    echo "$JSON_RPC_API" > ./schema.json
+    go run ./generate.go
+    rm ./schema.json
+    docker kill $CONTAINER_ID
+else
+    echo "Failed to retrieve JSON RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
+    docker kill $CONTAINER_ID
+    exit 1
+fi

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -8,7 +8,7 @@ if [ -z $ENGINE_VERSION ]; then
     echo "Using latest Engine version is $ENGINE_VERSION"
 fi
 
-# Retrieve the JSON RPC API from Qlik Analytics Engines REST API
+# Retrieve the JSON-RPC API from Qlik Analytics Engines REST API
 CONTAINER_ID=$(docker run -d -p 9076:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
 RETRIES=0
 while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
@@ -16,16 +16,15 @@ while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
   sleep 2
   RETRIES=$((RETRIES + 1 ))
 done
+docker kill $CONTAINER_ID
 
 # Generate enigma-go based on schema
 if [[ $JSON_RPC_API != "" ]]; then
-    echo "Generating enigma-go based on JSON RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
+    echo "Generating enigma-go based on JSON-RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
     echo "$JSON_RPC_API" > ./schema.json
     go run ./generate.go
     rm ./schema.json
-    docker kill $CONTAINER_ID
 else
-    echo "Failed to retrieve JSON RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
-    docker kill $CONTAINER_ID
+    echo "Failed to retrieve JSON-RPC API for Qlik Analytics Engine version $ENGINE_VERSION"
     exit 1
 fi


### PR DESCRIPTION
This PR adds a bash script for generating enigma-go based on a specific version of Qlik Analytics Engine and the JSON-RPC API.

Also added a cron job to make it easier to keep the enigma-go repo aligned with latest publish docker image of Qlik Analytics Engine.