### PR TITLE
Update golint path in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install toolchain
           command: |
             go get -u github.com/golang/dep/cmd/dep
-            go get -u github.com/golang/lint/golint
+            go get -u golang.org/x/lint/golint
       - restore_cache:
           key: dependency-cache-{{ checksum "Gopkg.lock" }}
       - run:


### PR DESCRIPTION
The path to `golint` is now updated and enforced per https://github.com/golang/lint/issues/415.