### PR TITLE
Always treat png as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # Unix line endings in all text files.
 * text eol=lf
+
+# Always treat images as binaries
+*.png binary


### PR DESCRIPTION
 to avoid problems when using autocrlf = true/input and avoiding the following error when using dep
```
Solving failure:
	(1) failed to clean up git repository at /gopath/pkg/dep/sources/https---github.com-qlik--oss-enigma--go - dirty? corrupted? status output:
 M enigma-go.png
```