### PR TITLE
Enable possibility for synchronously react on object changes

### DIFF
--- a/examples/basics/events/README.md
+++ b/examples/basics/events/README.md
@@ -4,6 +4,7 @@ This example will show you how to handle messages and events coming from a Qlik 
 * Session Messages
 * Object Layout Change Events
 * Object Close Events
+* Synchronously handle Change Events
 
 ## Runnable code
 

--- a/session.go
+++ b/session.go
@@ -23,9 +23,13 @@ type (
 		interceptorChain         InterceptorContinuation
 	}
 
+	// ChangeListsKey key for ChangeLists context value
 	ChangeListsKey struct{}
+	// ChangeLists list of changed and closed handles.
 	ChangeLists struct{
+		// Changed list of changed object handles or nil
 		Changed []int
+		// Closed  list of closed object handles or nil
 		Closed []int
 	}
 )


### PR DESCRIPTION
Adds functionality to synchronously get changed and closed objects after using an enigma method. 

_How to use_
Add a pointer to a `ChangeLists{}` as value to the context passed to enigma
```golang
cl := ChangeLists{}
ctx := context.WithValue(context.Background(), ChangeListsKey{}, &cl)
```
When the enigma method returns, the changes can be accessed by e.g.
```golang
for handle := range cl.Changed {
    // handle change on handle
}
```