### PR TITLE
Restore cache before linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,24 +5,23 @@ jobs:
       - image: circleci/golang:1.11
     steps:
       - checkout
-      - run:
-          name: Install lint
-          command: go get -u golang.org/x/lint/golint
-      - run:
-          name: Linting
-          command: golint -set_exit_status
       - restore_cache:
           key: dependency-cache-{{ checksum "go.sum" }}
       - run:
+          name: Linting
+          command: |
+            go get -u golang.org/x/lint/golint
+            golint -set_exit_status
+      - run:
           name: Build
           command: go build
+      - run:
+          name: Test
+          command: go test -v -race ./...
       - save_cache:
           key: dependency-cache-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-      - run:
-          name: Test
-          command: go test -v -race ./...
       - setup_remote_docker
       - run:
           name: Execute integration tests


### PR DESCRIPTION
The Circle CI builds are failing on master when the mod cache is used. The cache should be restored before running any other steps otherwise some dependencies are already downloaded.