### PR TITLE
Added support for listening on all change and close events for a session

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/jaytaylor/html2text v0.0.0-20190218062942-57d518f124b0 h1:ow8ZU1ovjZxBcbYyQ/ZjPl+cXzTwyINDw+u0gdQ4seo=
-github.com/jaytaylor/html2text v0.0.0-20190218062942-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
-github.com/jaytaylor/html2text v0.0.0-20190316160659-a93a6c6ea053/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
+github.com/jaytaylor/html2text v0.0.0-20190413004953-01ec452cbe43 h1:/3uNjPbXkW75QADl83jdccgLbeJhtFl6PKqSRsQu1rg=
 github.com/jaytaylor/html2text v0.0.0-20190413004953-01ec452cbe43/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -24,15 +22,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190216013615-3a22650c66bd h1:3MYvfuykMHO4Sl9IUzzk62U7w4vKRPsfoQcQbS9NDZI=
-golang.org/x/net v0.0.0-20190216013615-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190302044840-16b79f2e4e95/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190311033725-56fb01167e7d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190316004652-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190324225923-e3b2ff56ed87/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190330005656-74de082e2cca/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190406015636-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190420064333-afa5a82059c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190427005324-4829fb13d2c6 h1:SHnU4BQYUc3+f59fHV++yDcB8DZuA2Il9y5j0O/KxkQ=
 golang.org/x/net v0.0.0-20190427005324-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/session.go
+++ b/session.go
@@ -125,6 +125,7 @@ func (q *session) mainSessionLoop() {
 	}
 	q.socket.Close()
 	q.closeAllSessionEventChannels()
+	q.closeAllChangeListChannels()
 	close(q.disconnectedFromServerCh)
 
 }

--- a/session.go
+++ b/session.go
@@ -138,15 +138,12 @@ func (q *session) handleResponse(message []byte, receiveTimestamp time.Time) {
 		q.emitSessionMessage(rpcResponse.Method, rpcResponse.Params)
 	} else {
 		pendingCall := q.removePendingCall(rpcResponse.ID)
+		q.emitChangeLists(rpcResponse.Change, rpcResponse.Close, pendingCall == nil) // Emit this before marking the pending call as done to make sure it is there when the pending call returns
 		if pendingCall != nil {
 			pendingCall.Response = rpcResponse
 			pendingCall.receiveTimestamp = receiveTimestamp
 			pendingCall.messageSize = len(message)
-			q.emitChangeLists(pendingCall.Response.Change, pendingCall.Response.Close, false) // Emit this before marking the pending call as done to make sure it is there when the pending call returns
 			pendingCall.Done <- nil
-		} else {
-			q.emitChangeLists(pendingCall.Response.Change, pendingCall.Response.Close, true)
-			// Not a call response. Change and Close arrays
 		}
 	}
 	q.handleUpdates(rpcResponse.Change, rpcResponse.Close)

--- a/session_change_lists.go
+++ b/session_change_lists.go
@@ -1,0 +1,66 @@
+package enigma
+
+import (
+	"sync"
+)
+
+type (
+	sessionChangeLists struct {
+		mutex    sync.Mutex
+		channels map[*sessionChangeListEntry]bool
+	}
+
+	sessionChangeListEntry struct {
+		pushedOnly bool
+		channel    chan ChangeLists
+	}
+)
+
+func (e *sessionChangeLists) emitChangeLists(changed []int, closed []int, pushed bool) {
+	if len(changed) > 0 || len(closed) > 0 {
+		e.mutex.Lock()
+		defer e.mutex.Unlock()
+
+		for channelEntry := range e.channels {
+			if pushed || !channelEntry.pushedOnly {
+				channelEntry.channel <- ChangeLists{Changed: changed, Closed: closed}
+			}
+		}
+	}
+}
+
+// ChangeListsChannel returns a channel that receives change and close notifications from Qlik Associative Engine. if the pushedOnly argument is set to true
+// only pushed change lists are put into the channel - not changes that are returned as a response to an API call.
+func (e *sessionChangeLists) ChangeListsChannel(pushedOnly bool) chan ChangeLists {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	channelEntry := &sessionChangeListEntry{channel: make(chan ChangeLists, 16), pushedOnly: pushedOnly}
+	e.channels[channelEntry] = true
+	return channelEntry.channel
+}
+
+// CloseChangeListsChannel closes and unregisters the supplied event channel from the session.
+func (e *sessionChangeLists) CloseChangeListsChannel(channel chan ChangeLists) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	for channelEntry := range e.channels {
+		if channelEntry.channel == channel {
+			close(channelEntry.channel)
+			delete(e.channels, channelEntry)
+			break
+		}
+	}
+}
+
+func (e *sessionChangeLists) closeAllChangeListChannels() {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	for channelEntry := range e.channels {
+		close(channelEntry.channel)
+	}
+	e.channels = make(map[*sessionChangeListEntry]bool)
+}
+
+func newSessionChangeLists() *sessionChangeLists {
+	return &sessionChangeLists{channels: make(map[*sessionChangeListEntry]bool), mutex: sync.Mutex{}}
+}

--- a/session_change_lists_test.go
+++ b/session_change_lists_test.go
@@ -1,0 +1,44 @@
+package enigma
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSessionChangeLists(t *testing.T) {
+	// Set up two channels - on for all change lists, and one for all
+	s := newSessionChangeLists()
+	allChangeListsChannel := s.ChangeListsChannel(false)
+	pushedChangeListsChannel := s.ChangeListsChannel(true)
+
+	// Emit two lists
+	s.emitChangeLists([]int{1, 2}, []int{3, 4}, true)
+	s.emitChangeLists([]int{5, 6}, []int{7, 8}, false)
+
+	// Check that the lists appear as expecgted
+	allData1 := <-allChangeListsChannel
+	allData2 := <-allChangeListsChannel
+	assert.Equal(t, 1, allData1.Changed[0])
+	assert.Equal(t, 3, allData1.Closed[0])
+	assert.Equal(t, 5, allData2.Changed[0])
+	assert.Equal(t, 7, allData2.Closed[0])
+
+	pushedData1 := <-pushedChangeListsChannel
+	assert.Equal(t, 1, pushedData1.Changed[0])
+	assert.Equal(t, 3, pushedData1.Closed[0])
+
+	// Check that the second non-pushed list doesn't appear
+	var nothingInChangePushedChangeList bool
+	select {
+	case <-pushedChangeListsChannel:
+		nothingInChangePushedChangeList = false
+	default:
+		nothingInChangePushedChangeList = true
+	}
+	assert.True(t, nothingInChangePushedChangeList)
+
+	// Close listeners are check that they are actually deregistered
+	s.CloseChangeListsChannel(pushedChangeListsChannel)
+	s.CloseChangeListsChannel(allChangeListsChannel)
+	assert.Equal(t, len(s.channels), 0)
+}


### PR DESCRIPTION
Added ChangeListsChannel/CloseChangeListsChannel functions in the session to allow listening on all change lists coming in to the session. The ChangeListsChannel takes an argument pushedOnly that allows you to get a channel that only received pushed change lists