### PR TITLE
Run go mod tidy when renovating

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": [
     "qlik-oss",
     "qlik-oss:groupMinorPatch"
-  ]
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
When renovate bumps dependencies it should also run `go mod tidy` to clean up unused dependencies in `go.sum`.


