### PR TITLE
Fix errors to be compatible with go 1.11

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,11 +22,7 @@ type (
 )
 
 func (err *qixError) Error() string {
-	errorType := errorCodeLookup(err.ErrorCode)
-	if errorType[:7] == "LOCERR_" {
-		errorType = errorType[7:]
-	}
-	errorType = strings.ReplaceAll(errorType, "_", " ")
+	errorType := err.codeLookup()
 	return fmt.Sprintf("%s: %s (%d %s)", err.ErrorParameter, err.ErrorMessage, err.ErrorCode, errorType)
 }
 
@@ -40,4 +36,19 @@ func (err *qixError) Parameter() string {
 
 func (err *qixError) Message() string {
 	return err.ErrorMessage
+}
+
+func (err *qixError) codeLookup() string {
+	errorType := errorCodeLookup(err.ErrorCode)
+	if len(errorType) < 7 {
+		// All error codes should result in a string prefixed with LOCERR_
+		// if the code is valid, so this is probably invalid.
+		// Just return whatever was returned by the lookup to be safe.
+		return errorType
+	}
+	if errorType[:7] == "LOCERR_" {
+		errorType = errorType[7:]
+	}
+	errorType = strings.Replace(errorType, "_", " ", -1)
+	return errorType
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,20 @@
+package enigma
+
+import (
+	"testing"
+)
+
+func TestErrorCodeLookup(t *testing.T) {
+	err := qixError{}
+	// Error code -128 is an internal error.
+	err.ErrorCode = -128
+	expected := "INTERNAL ERROR"
+	if actual := err.codeLookup(); actual != expected {
+		t.Errorf("Expected: '%s', actual: '%s'", expected, actual)
+	}
+	// Error code -100 is not a valid error code.
+	err.ErrorCode = -100
+	if err.codeLookup() != "" {
+		t.Error("Expected empty string for invalid error code.")
+	}
+}


### PR DESCRIPTION
ReplaceAll was introduce in go 1.12, using Replace with -1 instead to be backwards compatible.