### PR TITLE
Run CCI pipeline for multiple golang versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ aliases:
       ENGINE_CONTAINER_ID=$(docker run -d qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
       ENGINE_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ENGINE_CONTAINER_ID)
       docker cp ./examples/reload/monitor-progress/testdata/ $ENGINE_CONTAINER_ID:/testdata
-      TEST_CONTAINER_ID=$(docker run -e "CGO_ENABLED=0" -d golang:1.12-alpine tail -f /dev/null)
+      TEST_CONTAINER_ID=$(docker run -e "CGO_ENABLED=0" -d golang:$GOLANG_VERSION-alpine tail -f /dev/null)
       docker cp /go/pkg $TEST_CONTAINER_ID:/go/pkg
       docker cp . $TEST_CONTAINER_ID:/enigma-go
       docker exec $TEST_CONTAINER_ID /bin/sh -c 'apk update && apk add --no-cache socat bash'
@@ -31,6 +31,8 @@ jobs:
   golang-1.11:
     docker:
       - image: circleci/golang:1.11
+    environment:
+      GOLANG_VERSION: "1.11"
     steps:
       - checkout
       - restore_cache:
@@ -52,6 +54,8 @@ jobs:
   golang-1.12:
     docker:
       - image: circleci/golang:1.12
+    environment:
+      GOLANG_VERSION: "1.12"
     steps:
       - checkout
       - restore_cache:
@@ -73,6 +77,8 @@ jobs:
   golang-1.13:
     docker:
       - image: circleci/golang:1.13
+    environment:
+      GOLANG_VERSION: "1.13"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,55 @@
+aliases:
+
+  - &lint
+    |
+      go fmt ./...
+      go get -u golang.org/x/lint/golint
+      golint -set_exit_status
+      # go fmt and golint can alter go.mod and go.sum.
+      # This will cause the git diff to give false negative.
+      # Restore those files before proceeding to avoid saif effect.
+      git checkout go.mod go.sum
+      git diff --exit-code
+
+  - &examples
+    |
+      ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
+      echo "Will start Qlik Associative Engine version '$ENGINE_VERSION'"
+      ENGINE_CONTAINER_ID=$(docker run -d qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
+      ENGINE_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ENGINE_CONTAINER_ID)
+      docker cp ./examples/reload/monitor-progress/testdata/ $ENGINE_CONTAINER_ID:/testdata
+      TEST_CONTAINER_ID=$(docker run -e "CGO_ENABLED=0" -d golang:1.12-alpine tail -f /dev/null)
+      docker cp /go/pkg $TEST_CONTAINER_ID:/go/pkg
+      docker cp . $TEST_CONTAINER_ID:/enigma-go
+      docker exec $TEST_CONTAINER_ID /bin/sh -c 'apk update && apk add --no-cache socat bash'
+      docker exec -d $TEST_CONTAINER_ID /bin/bash -c "socat TCP-LISTEN:9076,fork TCP:$ENGINE_IP:9076"
+      docker exec $TEST_CONTAINER_ID /bin/bash -c '/enigma-go/examples/run_examples.sh'
+
 version: 2
 jobs:
-  build:
+
+  golang-1.11:
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "go.sum" }}
+      - run:
+          name: Build
+          command: go build
+      - save_cache:
+          key: dependency-cache-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run: *lint
+      - run:
+          name: Test
+          command: go test -v -race .
+      - setup_remote_docker
+      - run: *examples
+
+  golang-1.12:
     docker:
       - image: circleci/golang:1.12
     steps:
@@ -14,32 +63,38 @@ jobs:
           key: dependency-cache-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-      - run:
-          name: Linting
-          command: |
-            go fmt ./...
-            go get -u golang.org/x/lint/golint
-            golint -set_exit_status
-            # go fmt and golint can alter go.mod and go.sum.
-            # This will cause the git diff to give false negative.
-            # Restore those files before proceeding to avoid saif effect.
-            git checkout go.mod go.sum
-            git diff --exit-code
+      - run: *lint
       - run:
           name: Test
           command: go test -v -race .
       - setup_remote_docker
+      - run: *examples
+
+  golang-1.13:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "go.sum" }}
       - run:
-          name: Execute integration tests
-          command: |
-            ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
-            echo "Will start Qlik Associative Engine version '$ENGINE_VERSION'"
-            ENGINE_CONTAINER_ID=$(docker run -d qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)
-            ENGINE_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ENGINE_CONTAINER_ID)
-            docker cp ./examples/reload/monitor-progress/testdata/ $ENGINE_CONTAINER_ID:/testdata
-            TEST_CONTAINER_ID=$(docker run -e "CGO_ENABLED=0" -d golang:1.12-alpine tail -f /dev/null)
-            docker cp /go/pkg $TEST_CONTAINER_ID:/go/pkg
-            docker cp . $TEST_CONTAINER_ID:/enigma-go
-            docker exec $TEST_CONTAINER_ID /bin/sh -c 'apk update && apk add --no-cache socat bash'
-            docker exec -d $TEST_CONTAINER_ID /bin/bash -c "socat TCP-LISTEN:9076,fork TCP:$ENGINE_IP:9076"
-            docker exec $TEST_CONTAINER_ID /bin/bash -c '/enigma-go/examples/run_examples.sh'
+          name: Build
+          command: go build
+      - save_cache:
+          key: dependency-cache-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run: *lint
+      - run:
+          name: Test
+          command: go test -v -race .
+      - setup_remote_docker
+      - run: *examples
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - golang-1.11
+      - golang-1.12
+      - golang-1.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 aliases:
 
   - &build
-    |
       go build
 
-  - &lint
-    |
+  - &lint |
       go fmt ./...
       go get -u golang.org/x/lint/golint
       golint -set_exit_status
@@ -16,11 +14,9 @@ aliases:
       git diff --exit-code
 
   - &test
-    |
       go test -v -race .
 
-  - &examples
-    |
+  - &examples |
       ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
       echo "Will start Qlik Associative Engine version '$ENGINE_VERSION'"
       ENGINE_CONTAINER_ID=$(docker run -d qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=yes)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,8 @@
 aliases:
 
-  - &restore-cache
-    key: dependency-cache-$GOLANG_VERSION{{ checksum "go.sum" }}
-
   - &build
     |
       go build
-
-  - &save-cache
-    key: dependency-cache-$GOLANG_VERSION{{ checksum "go.sum" }}
-    paths:
-      - "/go/pkg/mod"
 
   - &lint
     |
@@ -51,9 +43,13 @@ jobs:
       GOLANG_VERSION: "1.11"
     steps:
       - checkout
-      - restore_cache: *restore-cache
+      - restore_cache:
+          key: dependency-cache-1.11{{ checksum "go.sum" }}
       - run: *build
-      - save_cache: *save-cache
+      - save_cache:
+          key: dependency-cache-1.11{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
       - run: *lint
       - run: *test
       - setup_remote_docker
@@ -66,9 +62,13 @@ jobs:
       GOLANG_VERSION: "1.12"
     steps:
       - checkout
-      - restore_cache: *restore-cache
+      - restore_cache:
+          key: dependency-cache-1.12{{ checksum "go.sum" }}
       - run: *build
-      - save_cache: *save-cache
+      - save_cache:
+          key: dependency-cache-1.12{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
       - run: *lint
       - run: *test
       - setup_remote_docker
@@ -81,9 +81,13 @@ jobs:
       GOLANG_VERSION: "1.13"
     steps:
       - checkout
-      - restore_cache: *restore-cache
+      - restore_cache:
+          key: dependency-cache-1.13{{ checksum "go.sum" }}
       - run: *build
-      - save_cache: *save-cache
+      - save_cache:
+          key: dependency-cache-1.13{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
       - run: *lint
       - run: *test
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 aliases:
 
   - &restore-cache
-    key: dependency-cache-{{ checksum "go.sum" }}
+    key: dependency-cache-$GOLANG_VERSION{{ checksum "go.sum" }}
 
   - &build
     |
       go build
 
   - &save-cache
-    key: dependency-cache-{{ checksum "go.sum" }}
+    key: dependency-cache-$GOLANG_VERSION{{ checksum "go.sum" }}
     paths:
       - "/go/pkg/mod"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 aliases:
 
+  - &restore-cache
+    key: dependency-cache-{{ checksum "go.sum" }}
+
+  - &build
+    |
+      go build
+
+  - &save-cache
+    key: dependency-cache-{{ checksum "go.sum" }}
+    paths:
+      - "/go/pkg/mod"
+
   - &lint
     |
       go fmt ./...
@@ -10,6 +22,10 @@ aliases:
       # Restore those files before proceeding to avoid saif effect.
       git checkout go.mod go.sum
       git diff --exit-code
+
+  - &test
+    |
+      go test -v -race .
 
   - &examples
     |
@@ -35,19 +51,11 @@ jobs:
       GOLANG_VERSION: "1.11"
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-      - run:
-          name: Build
-          command: go build
-      - save_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      - restore_cache: *restore-cache
+      - run: *build
+      - save_cache: *save-cache
       - run: *lint
-      - run:
-          name: Test
-          command: go test -v -race .
+      - run: *test
       - setup_remote_docker
       - run: *examples
 
@@ -58,19 +66,11 @@ jobs:
       GOLANG_VERSION: "1.12"
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-      - run:
-          name: Build
-          command: go build
-      - save_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      - restore_cache: *restore-cache
+      - run: *build
+      - save_cache: *save-cache
       - run: *lint
-      - run:
-          name: Test
-          command: go test -v -race .
+      - run: *test
       - setup_remote_docker
       - run: *examples
 
@@ -81,19 +81,11 @@ jobs:
       GOLANG_VERSION: "1.13"
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-      - run:
-          name: Build
-          command: go build
-      - save_cache:
-          key: dependency-cache-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      - restore_cache: *restore-cache
+      - run: *build
+      - save_cache: *save-cache
       - run: *lint
-      - run:
-          name: Test
-          command: go test -v -race .
+      - run: *test
       - setup_remote_docker
       - run: *examples
 


### PR DESCRIPTION
To secure the backwards compatibility in `enigma-go` we need to test against multiple golang versions in Circle CI. This PR adds jobs for versions `1.11`, `1.12` and `1.13` to the config.

This closes #95 