### PR TITLE
Renovate should ignore golang version in cci

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
     "qlik-oss",
     "qlik-oss:groupMinorPatch"
   ],
-  "postUpdateOptions": ["gomodTidy"]
+  "postUpdateOptions": ["gomodTidy"],
+  "ignoreDeps": ["circleci/golang"]
 }


### PR DESCRIPTION
Since we want to test multiple golang versions in Circle CI, then we need to disable renovate from bumping to newer golang versions.
