### PR TITLE
Circleci API specification test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,12 @@ aliases:
 
   - &spec_test |
       go test -v -race ./spec
-      go run ./spec/generate.go
+      TAG=$(git describe --tags --abbrev=0)
+      if [[ $(git rev-list -n 1 $TAG) == $(git rev-parse HEAD) ]]; then
+        go run ./spec/generate.go -version $TAG
+      else
+        go run ./spec/generate.go
+      fi
       git diff --exit-code api-spec.json
 
   - &examples |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ aliases:
       # If we don't have any tags we will get exit code 128.
       # Ignore it, the last diff is what's important here.
       TAG=$(git describe --tags --abbrev=0 2> /dev/null)
+      set -e
       if [[ ! -z $TAG && ($(git rev-list -n 1 $TAG) == $(git rev-parse HEAD)) ]]; then
         go run ./spec/generate.go -version $TAG
       else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,11 @@ aliases:
 
   - &spec_test |
       go test -v -race ./spec
-      TAG=$(git describe --tags --abbrev=0)
-      if [[ $(git rev-list -n 1 $TAG) == $(git rev-parse HEAD) ]]; then
+      set +e
+      # If we don't have any tags we will get exit code 128.
+      # Ignore it, the last diff is what's important here.
+      TAG=$(git describe --tags --abbrev=0 2> /dev/null)
+      if [[ ! -z $TAG && ($(git rev-list -n 1 $TAG) == $(git rev-parse HEAD)) ]]; then
         go run ./spec/generate.go -version $TAG
       else
         go run ./spec/generate.go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,9 @@ aliases:
 
   - &spec_test |
       go test -v -race ./spec
-      set +e
-      # If we don't have any tags we will get exit code 128.
-      # Ignore it, the last diff is what's important here.
+      set +e # If we don't have any tags we will get exit code 128.
       TAG=$(git describe --tags --abbrev=0 2> /dev/null)
-      set -e
+      set -e # Reset -e just in case
       if [[ ! -z $TAG && ($(git rev-list -n 1 $TAG) == $(git rev-parse HEAD)) ]]; then
         go run ./spec/generate.go -version $TAG
       else

--- a/api-spec.json
+++ b/api-spec.json
@@ -4,7 +4,7 @@
     "name": "enigma",
     "go-package-name": "enigma",
     "go-package-import-path": "github.com/qlik-oss/enigma-go",
-    "version": "apricots!",
+    "version": "devbuild",
     "description": "enigma-go is a library that helps you communicate with a Qlik Associative Engine.",
     "license": "MIT"
   },

--- a/api-spec.json
+++ b/api-spec.json
@@ -4,7 +4,7 @@
     "name": "enigma",
     "go-package-name": "enigma",
     "go-package-import-path": "github.com/qlik-oss/enigma-go",
-    "version": "devbuild",
+    "version": "apricots!",
     "description": "enigma-go is a library that helps you communicate with a Qlik Associative Engine.",
     "license": "MIT"
   },

--- a/release/release.sh
+++ b/release/release.sh
@@ -47,16 +47,16 @@ sanity_check() {
     git status --porcelain
     exit 1
   fi
+  if [[ $(git branch | grep -oP "\*\s\K.+") != "master" ]]; then
+    echo "This script should only be run from the master branch. Aborting."
+    exit 1
+  fi
   # Check if local branch is up-to-date with remote master branch
   git fetch origin master
   git diff origin/master --exit-code > /dev/null
   if [[ $? -ne 0 ]]; then
     echo "Local branch is not up-to-date with remote master. Please pull the latest changes."
     git diff origin/master --name-only
-    exit 1
-  fi
-  if [[ $(git branch | grep -oP "\*\s\K.+") != "master" ]]; then
-    echo "This script should only be run from the master branch. Aborting."
     exit 1
   fi
 }

--- a/release/release.sh
+++ b/release/release.sh
@@ -47,7 +47,7 @@ sanity_check() {
     git status --porcelain
     exit 1
   fi
-  local_branch=$(git branch | grep -oP "\*\s\K.+")
+  local_branch=$(git rev-parse --abbrev-ref HEAD)
   if [[ $local_branch != "master" ]]; then
     echo "This script can only be run from the master branch."
     echo "You are on '$local_branch'. Aborting."

--- a/release/release.sh
+++ b/release/release.sh
@@ -49,8 +49,8 @@ sanity_check() {
   fi
   local_branch=$(git branch | grep -oP "\*\s\K.+")
   if [[ $local_branch != "master" ]]; then
-    echo "This script should only be run from the master branch."
-    echo "You are on $local_branch. Aborting."
+    echo "This script can only be run from the master branch."
+    echo "You are on '$local_branch'. Aborting."
     exit 1
   fi
   # Check if local branch is up-to-date with remote master branch

--- a/release/release.sh
+++ b/release/release.sh
@@ -55,6 +55,10 @@ sanity_check() {
     git diff origin/master --name-only
     exit 1
   fi
+  if [[ $(git branch | grep -oP "\*\s\K.+") != "master" ]]; then
+    echo "This script should only be run from the master branch. Aborting."
+    exit 1
+  fi
 }
 
 case $1 in

--- a/release/release.sh
+++ b/release/release.sh
@@ -47,8 +47,10 @@ sanity_check() {
     git status --porcelain
     exit 1
   fi
-  if [[ $(git branch | grep -oP "\*\s\K.+") != "master" ]]; then
-    echo "This script should only be run from the master branch. Aborting."
+  local_branch=$(git branch | grep -oP "\*\s\K.+")
+  if [[ $local_branch != "master" ]]; then
+    echo "This script should only be run from the master branch."
+    echo "You are on $local_branch. Aborting."
     exit 1
   fi
   # Check if local branch is up-to-date with remote master branch

--- a/spec/generate.go
+++ b/spec/generate.go
@@ -34,7 +34,7 @@ type info struct {
 	Name                string `json:"name,omitempty"`
 	GoPackageName       string `json:"go-package-name,omitempty"`
 	GoPackageImportPath string `json:"go-package-import-path,omitempty"`
-	Version             string `json:"version,omitempty"`
+	Version             string `json:"version"`
 	Description         string `json:"description,omitempty"`
 	License             string `json:"license,omitempty"`
 	Deprecated          bool   `json:"x-qlik-deprecated,omitempty"`


### PR DESCRIPTION
What the added code is meant to do is to run the API specification generation in the testing differently if the commit being tested has a tag on it. In that case, it should generate the spec with the version flag set to whatever the tag was.

I used `set +e` to ignore the exit code 128 you get from `git describe --tag` without tags. We should instead determine pass or fail based on the tests and on the git diff at the end.