### PR TITLE
Release tag no longer contains metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,8 @@ workflows:
       - golang-1.11
       - golang-1.12
       - golang-1.13
-    fitlers:
-      tags:
-        only:
-          - /v.*/
+      - golang-1.13
+          filters:
+            tags:
+              only:
+                - /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,7 @@ workflows:
       - golang-1.11
       - golang-1.12
       - golang-1.13
-      - golang-1.13
-          filters:
-            tags:
-              only:
-                - /v.*/
+    filters:
+      tags:
+        only:
+          - /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,3 +110,7 @@ workflows:
       - golang-1.11
       - golang-1.12
       - golang-1.13
+    fitlers:
+      tags:
+        only:
+          - /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,11 @@ jobs:
 workflows:
   version: 2
   build:
-    filters:
-      tags:
-        only:
-          - /v.*/
     jobs:
       - golang-1.11
       - golang-1.12
-      - golang-1.13
+      - golang-1.13:
+          filters:
+            tags:
+              only:
+                - /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,11 @@ jobs:
 workflows:
   version: 2
   build:
-    jobs:
-      - golang-1.11
-      - golang-1.12
-      - golang-1.13
     filters:
       tags:
         only:
           - /v.*/
+    jobs:
+      - golang-1.11
+      - golang-1.12
+      - golang-1.13

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ where the argument specifies what should be bumped. The release-script does a co
 1. Creates a new version based on previous version-tag (if any, otherwise 0.0.0) and suffixes it with the QIX schema version
 as metadata. For example bumping minor when there are no previous tags will result in the version `0.1.0+12.429.0`.
 2. Generates a new API specification using the new version.
-3. Adds the resulting `api-spec.json` file to a commit with the message `Release: <version>`.
+3. Adds the resulting `api-spec.json` file to a commit with the message `Release: <version> for QIX schema version <qix_version>`.
 4. Creates a tag containing the version with the same message as in step 3.
+5. Afterwards, adds another commit bumping the `api-spec.json` to latest again.
 
 After the script has run, check the results. If everything looks good run:
 ```bash

--- a/api-spec.json
+++ b/api-spec.json
@@ -4,7 +4,7 @@
     "name": "enigma",
     "go-package-name": "enigma",
     "go-package-import-path": "github.com/qlik-oss/enigma-go",
-    "version": "devbuild",
+    "version": "latest",
     "description": "enigma-go is a library that helps you communicate with a Qlik Associative Engine.",
     "license": "MIT"
   },

--- a/api-spec.json
+++ b/api-spec.json
@@ -4,7 +4,7 @@
     "name": "enigma",
     "go-package-name": "enigma",
     "go-package-import-path": "github.com/qlik-oss/enigma-go",
-    "version": "v0.1.0+12.429.0",
+    "version": "devbuild",
     "description": "enigma-go is a library that helps you communicate with a Qlik Associative Engine.",
     "license": "MIT"
   },

--- a/release/release.sh
+++ b/release/release.sh
@@ -3,7 +3,10 @@
 # If no tags are present, this will be interpreted '0.0.0'.
 #
 # After the version has been generated the tag will be added.
+# Finally, a commit bumping the api spec to version=latest is added.
 # Pushing the tag is left as an exercise to the reader.
+#
+# NOTE: This script should generate exactly 2 commits and 1 tag.
 
 VERSION=""
 bump_version() {
@@ -35,11 +38,6 @@ bump_version() {
   VERSION=v$new_ver
 }
 
-if [[ $# -ne 1 ]]; then
-  echo "use: release.sh <major|minor|patch>"
-  exit 1
-fi
-
 sanity_check() {
   if [[ ! -z $(git status --porcelain) ]]; then
     echo "There are uncommitted changes. Please make sure branch is clean."
@@ -61,6 +59,11 @@ sanity_check() {
     exit 1
   fi
 }
+
+if [[ $# -ne 1 ]]; then
+  echo "use: release.sh <major|minor|patch>"
+  exit 1
+fi
 
 case $1 in
   "major"|"minor"|"patch")
@@ -86,6 +89,10 @@ case $1 in
     git commit -m $MSG > /dev/null
     echo "git tag -a ${VERSION} -m $MSG"
     git tag -a $VERSION -m $MSG > /dev/null
+    # Set version to latest on master
+    go run generate.go
+    echo "git commit -m \"Post-release: bumping version to latest\""
+    git commit -m "Post-release: bumping version to latest" > /dev/null
     echo
     echo "If everything looks OK run the following command to release:"
     echo

--- a/release/release.sh
+++ b/release/release.sh
@@ -90,7 +90,10 @@ case $1 in
     echo "git tag -a ${VERSION} -m $MSG"
     git tag -a $VERSION -m $MSG > /dev/null
     # Set version to latest on master
+    echo "Bumping version of spec again, now to latest"
     go run generate.go
+    echo "git add ../api-spec.json"
+    git add ../api-spec.json > /dev/null
     echo "git commit -m \"Post-release: bumping version to latest\""
     git commit -m "Post-release: bumping version to latest" > /dev/null
     echo

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,8 +1,7 @@
 # !/bin/bash
-# This script bumps the version based on the previous tag
-# and appends engine version as metadata. If no tags are
-# present, this will be interpreted '0.0.0'.
-
+# This script bumps the version based on the previous tag.
+# If no tags are present, this will be interpreted '0.0.0'.
+#
 # After the version has been generated the tag will be added.
 # Pushing the tag is left as an exercise to the reader.
 
@@ -33,7 +32,7 @@ bump_version() {
     exit $ecode
   fi
   echo "New version: $new_ver"
-  VERSION=v$new_ver+$(grep -oP "QIX_SCHEMA_VERSION.+?\K\d+\.\d+\.\d+" ../qix_generated.go)
+  VERSION=v$new_ver
 }
 
 if [[ $# -ne 1 ]]; then
@@ -79,12 +78,14 @@ case $1 in
       exit 1
     fi
     echo "Done"
+    QIX_VERSION=$(grep "QIX_SCHEMA_VERSION" qix_generated.go | cut -d ' ' -f4 | sed 's/"//g')
+    MSG="Release: $VERSION for QIX schema version $QIX_VERSION"
     echo "git add ../api-spec.json"
     git add ../api-spec.json > /dev/null
-    echo "git commit -m \"Release: $VERSION\""
-    git commit -m "Release: $VERSION" > /dev/null
-    echo "git tag -a ${VERSION} -m Release: ${VERSION}"
-    git tag -a $VERSION -m "Release: ${VERSION}" > /dev/null
+    echo "git commit -m $MSG"
+    git commit -m $MSG > /dev/null
+    echo "git tag -a ${VERSION} -m $MSG"
+    git tag -a $VERSION -m $MSG > /dev/null
     echo
     echo "If everything looks OK run the following command to release:"
     echo

--- a/spec/generate.go
+++ b/spec/generate.go
@@ -81,7 +81,7 @@ func receiver(f *ast.FuncDecl) string {
 	return recv
 }
 
-var version = flag.String("version", "devbuild", "Specification version")
+var version = flag.String("version", "latest", "Specification version")
 var currentPackage string
 
 func main() {


### PR DESCRIPTION
For compatibility issues regarding go's module handling we will remove the metadata information from future release tags.