### PR TITLE
Improved cci when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,16 @@ workflows:
   version: 2
   build:
     jobs:
-      - golang-1.11
-      - golang-1.12
+      - golang-1.11:
+          filters:
+            tags:
+              only:
+                - /v.*/
+      - golang-1.12:
+          filters:
+            tags:
+              only:
+                - /v.*/
       - golang-1.13:
           filters:
             tags:


### PR DESCRIPTION
Circleci will now run the tests against golang 1.11, 1.12 and 1.13, not only 1.13.