### PR TITLE
Avoid deadlocking mainSessionLoop

### DIFF
--- a/session.go
+++ b/session.go
@@ -92,6 +92,7 @@ func (q *session) mainSessionLoop() {
 				err := socket.WriteMessage(1, outgoingMessage)
 				if err != nil {
 					socketError <- err
+					return
 				}
 			}
 		}


### PR DESCRIPTION
Since order of case `select` is not guaranteed we got deadlock in a small percentage of cases due to `socketError` channel filling up when having multiple parallel write requests and the heartbeat picked the `<-q.outgoingMessages` instead of `<-socketError` case multiple subsequent times. Exiting the go-routine directly after writing to `socketError` mitigates the deadlock.