### PR TITLE
Change float marshal to normal receiver function

### DIFF
--- a/float.go
+++ b/float.go
@@ -29,8 +29,8 @@ func (value *Float64) UnmarshalJSON(arg []byte) error {
 }
 
 // MarshalJSON implements the Marshaler interface for custom marshalling.
-func (value *Float64) MarshalJSON() ([]byte, error) {
-	val := float64(*value)
+func (value Float64) MarshalJSON() ([]byte, error) {
+	val := float64(value)
 	if math.IsNaN(val) {
 		return []byte(`"NaN"`), nil
 	} else if math.IsInf(val, 1) {
@@ -38,5 +38,5 @@ func (value *Float64) MarshalJSON() ([]byte, error) {
 	} else if math.IsInf(val, -1) {
 		return []byte(`"-Infinity"`), nil
 	}
-	return json.Marshal(float64(*value))
+	return json.Marshal(float64(value))
 }

--- a/float_test.go
+++ b/float_test.go
@@ -7,7 +7,75 @@ import (
 	"testing"
 )
 
-func TestFloat_UnmarshalJSON(t *testing.T) {
+func TestFloatMarshalJSON(t *testing.T) {
+	cases := []struct{
+		float float64
+		exp string
+	}{
+		{math.NaN(), `"NaN"`},
+		{math.Inf(1), `"Infinity"`},
+		{math.Inf(-1), `"-Infinity"`},
+		{1.0, "1"},
+	}
+	for _, cas := range cases {
+		float := Float64(cas.float)
+		ptr := &float
+		var floatBytes, ptrBytes []byte
+		var err error
+		if floatBytes, err = json.Marshal(float); err != nil {
+			t.Error(err)
+			continue
+		}
+		if ptrBytes, err = json.Marshal(ptr); err != nil {
+			t.Error(err)
+			continue
+		}
+		if string(floatBytes) != string(ptrBytes) {
+			t.Errorf("JSON should be equal for pointer and value")
+			t.Log(" Float64:", string(floatBytes))
+			t.Log("*Float64:", string(ptrBytes))
+		}
+		if string(floatBytes) != cas.exp {
+			t.Errorf("Expected %q got %q", cas.exp, string(floatBytes))
+		}
+	}
+}
+
+func TestFloatUnmarshalJSON(t *testing.T) {
+	cases := []struct{
+		b string
+		exp Float64
+	}{
+		{`"NaN"`, Float64(math.NaN())},
+		{`"Infinity"`, Float64(math.Inf(1))},
+		{`"-Infinity"`, Float64(math.Inf(-1))},
+		{"1", 1},
+	}
+	for _, cas := range cases {
+		var f Float64
+		err := json.Unmarshal([]byte(cas.b), &f)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if f != cas.exp {
+			if !(math.IsNaN(float64(f)) && math.IsNaN(float64(cas.exp))) {
+				t.Errorf("Expected '%T: %v' got '%T: %v'",
+					cas.exp, cas.exp, f, f)
+			}
+		}
+	}
+}
+
+func TestFloatNonPointerUnmarshalJSON(t *testing.T) {
+	var f Float64
+	err := json.Unmarshal([]byte("1"), f)
+	if err == nil {
+		t.Error("Should not be able to unmarshal non-pointer")
+	}
+}
+
+func TestFloatCompoundUnmarshalJSON(t *testing.T) {
 	var cell NxCell
 	_ = json.Unmarshal([]byte(`{"qNum":"Infinity"}`), &cell)
 	assert.True(t, math.IsInf(float64(cell.Num), 1))
@@ -25,7 +93,7 @@ func TestFloat_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, float64(-125), float64(cell.Num))
 }
 
-func TestFloat_MarshalJSON(t *testing.T) {
+func TestFloatCompoundMarshalJSON(t *testing.T) {
 	var cell NxCell
 	var result []byte
 	cell.Num = -125

--- a/float_test.go
+++ b/float_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestFloatMarshalJSON(t *testing.T) {
-	cases := []struct{
+	cases := []struct {
 		float float64
-		exp string
+		exp   string
 	}{
 		{math.NaN(), `"NaN"`},
 		{math.Inf(1), `"Infinity"`},
@@ -42,8 +42,8 @@ func TestFloatMarshalJSON(t *testing.T) {
 }
 
 func TestFloatUnmarshalJSON(t *testing.T) {
-	cases := []struct{
-		b string
+	cases := []struct {
+		b   string
 		exp Float64
 	}{
 		{`"NaN"`, Float64(math.NaN())},

--- a/schema/generate.go
+++ b/schema/generate.go
@@ -502,9 +502,10 @@ func printMethod(method *OpenRpcMethod, out *os.File, serviceName string, method
 			// Replace the generic ObjectInterface pointer with the right Remote Object API struct
 			objectTypeName := objectFuncToObject[serviceName+"."+methodName]
 			if objectTypeName == "" {
-				panic("Unknown remote object type for " + serviceName + "." + methodName)
+				fmt.Fprint(out, "*RemoteObject, ")
+			} else {
+				fmt.Fprint(out, "*"+objectTypeName, ", ")
 			}
-			fmt.Fprint(out, "*"+objectTypeName, ", ")
 		} else {
 			fmt.Fprint(out, typeName, ", ")
 		}
@@ -560,7 +561,11 @@ func printMethod(method *OpenRpcMethod, out *os.File, serviceName string, method
 		responseType := actualResponseMap[responseKey]
 		if getTypeName(responseType) == "*ObjectInterface" {
 			objectAPITypeName := objectFuncToObject[serviceName+"."+methodName]
-			fmt.Fprint(out, "&"+objectAPITypeName+"{obj.session.getRemoteObject(result."+responseKey.Key[1:]+")}, ")
+			if objectAPITypeName == "" {
+				fmt.Fprint(out, "obj.session.getRemoteObject(result."+responseKey.Key[1:]+"), ")
+			} else {
+				fmt.Fprint(out, "&"+objectAPITypeName+"{obj.session.getRemoteObject(result."+responseKey.Key[1:]+")}, ")
+			}
 		} else {
 			fmt.Fprint(out, "result."+toPublicMemberName(responseKey.Key)+", ")
 		}
@@ -600,9 +605,10 @@ func printRawMethod(method *OpenRpcMethod, out *os.File, serviceName string, met
 		if typeName == "*ObjectInterface" {
 			objectTypeName := objectFuncToObject[serviceName+"."+methodName]
 			if objectTypeName == "" {
-				panic("Unknown remote object type for" + serviceName + "." + methodName)
+				fmt.Fprint(out, "*RemoteObject, ")
+			} else {
+				fmt.Fprint(out, "*"+objectTypeName, ", ")
 			}
-			fmt.Fprint(out, "*"+objectTypeName, ", ")
 		} else {
 			fmt.Fprint(out, getRawOutputTypeName(response), ", ")
 		}
@@ -657,7 +663,11 @@ func printRawMethod(method *OpenRpcMethod, out *os.File, serviceName string, met
 		responseType := actualResponseMap[responseKey]
 		if getTypeName(responseType) == "*ObjectInterface" {
 			objectAPITypeName := objectFuncToObject[serviceName+"."+methodName]
-			fmt.Fprint(out, "&"+objectAPITypeName+"{obj.session.getRemoteObject(result."+responseKey.Key[1:]+")}, ")
+			if objectAPITypeName == "" {
+				fmt.Fprint(out, "obj.session.getRemoteObject(result."+responseKey.Key[1:]+"), ")
+			} else {
+				fmt.Fprint(out, "&"+objectAPITypeName+"{obj.session.getRemoteObject(result."+responseKey.Key[1:]+")}, ")
+			}
 		} else {
 			fmt.Fprint(out, "result."+toPublicMemberName(responseKey.Key)+", ")
 		}


### PR DESCRIPTION
Changing function to be a receiver instead of a pointer receiver. This will allow Marshal of any `enigma.Float64` or `*enigma.Float64` to be valid.

I did not update the Unmarshal function however, since it doesn't make sense to do so. If it is a normal receiver, we cannot modify anything outside of the function scope.