### PR TITLE
Export error code lookup function

### DIFF
--- a/api-spec.json
+++ b/api-spec.json
@@ -5539,6 +5539,19 @@
         }
       }
     },
+    "ErrorCodeLookup": {
+      "type": "function",
+      "params": [
+        {
+          "type": "int"
+        }
+      ],
+      "returns": [
+        {
+          "type": "string"
+        }
+      ]
+    },
     "ErrorData": {
       "type": "struct",
       "entries": {

--- a/error.go
+++ b/error.go
@@ -39,7 +39,7 @@ func (err *qixError) Message() string {
 }
 
 func (err *qixError) codeLookup() string {
-	errorType := errorCodeLookup(err.ErrorCode)
+	errorType := ErrorCodeLookup(err.ErrorCode)
 	if len(errorType) < 7 {
 		// All error codes should result in a string prefixed with LOCERR_
 		// if the code is valid, so this is probably invalid.

--- a/qix_generated.go
+++ b/qix_generated.go
@@ -3111,7 +3111,7 @@ type NxListObjectExpressionDef struct {
 	LibraryId string `json:"qLibraryId,omitempty"`
 }
 
-func errorCodeLookup(c int) string {
+func ErrorCodeLookup(c int) string {
 	switch c {
 	case -128:
 		return "LOCERR_INTERNAL_ERROR"

--- a/schema/generate.go
+++ b/schema/generate.go
@@ -703,7 +703,7 @@ func printExtensionTags(out *os.File, indent string, extensions QlikExtensions) 
 }
 
 func printErrorCodeLookup(out *os.File, def *Type) {
-	fmt.Fprintln(out, "func errorCodeLookup(c int) string {")
+	fmt.Fprintln(out, "func ErrorCodeLookup(c int) string {")
 	fmt.Fprintln(out, "switch c {")
 	for _, opt := range def.OneOf {
 		fmt.Fprintln(out, "case", opt.ConstValue, ":")


### PR DESCRIPTION
Export `errorCodeLookup` so error codes can be looked up to get the string for code of e.g. `NxValidationError`.
