### PR TITLE
docs: switch to dev-portal docs links

### DIFF
--- a/examples/basics/custom-type/README.md
+++ b/examples/basics/custom-type/README.md
@@ -8,5 +8,5 @@ This example will show you how to create and interact with custom object types.
 
 ## Documentation
 
-* [Generic objects](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/overview-generic-object.htm)
-* [Properties of generic objects](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/Properties.htm)
+* [Generic object model](https://qlik.dev/libraries-and-tools/enigmajs/#generic-object-model)
+* [Generic Object Properties](https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FGenericObjectProperties)

--- a/examples/basics/custom-type/README.md
+++ b/examples/basics/custom-type/README.md
@@ -8,5 +8,5 @@ This example will show you how to create and interact with custom object types.
 
 ## Documentation
 
-* [Generic object model](https://qlik.dev/libraries-and-tools/enigmajs/#generic-object-model)
-* [Generic Object Properties](https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FGenericObjectProperties)
+* [Generic object model](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/overview-generic-object.htm)
+* [Generic Object Properties](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/Properties.htm)

--- a/examples/data/list-object/README.md
+++ b/examples/data/list-object/README.md
@@ -9,6 +9,6 @@ in it.
 
 ## Documentation
 
-* [Qlik Sense Help: List Object definition](http://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/PropertyLevel/ListObjectDef.htm)
-* [Qlik Sense Help: List Object layout](http://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/GenericObject/LayoutLevel/ListObject.htm)
-* [Qlik Sense Help: `selectListObjectValues()`](http://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/Classes/GenericObjectClass/GenericObject-class-SelectListObjectValues-method.htm)
+* [Qlik developer portal: List Object definition](https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FListObjectDef)
+* [Qlik developer portal: ListObject layout](https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FListObject)
+* [Qlik developer portal: SelectListObjectValues method](https://qlik.dev/apis/json-rpc/qix/genericobject#%23%2Fentries%2FGenericObject%2Fentries%2FSelectListObjectValues)

--- a/examples/data/string-expression/README.md
+++ b/examples/data/string-expression/README.md
@@ -8,4 +8,4 @@ This example will show you how to create a string expression and evaluate it.
 
 ## Documentation
 
-* [Qlik Sense Help: String Expression](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/Structs/StringExpression.htm)
+* [Qlik developer portal: String Expression](https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FStringExpression)

--- a/examples/reload/monitor-progress/README.md
+++ b/examples/reload/monitor-progress/README.md
@@ -13,5 +13,5 @@ To run this example, a running Qlik Associative Engine with access to the [./tes
 
 ## Documentation
 
-* [Qlik Sense Help: DoReload method](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/Classes/AppClass/App-class-DoReload-method.htm)
-* [Qlik Sense Help: GetProgress method](https://help.qlik.com/en-US/sense-developer/June2017/Subsystems/EngineAPI/Content/Classes/GlobalClass/Global-class-GetProgress-method.htm)
+* [Qlik developer portal: DoReload method](https://qlik.dev/apis/json-rpc/qix/doc#%23%2Fentries%2FDoc%2Fentries%2FDoReload)
+* [Qlik developer portal: GetProgress method](https://qlik.dev/apis/json-rpc/qix/global#%23%2Fentries%2FGlobal%2Fentries%2FGetProgress)


### PR DESCRIPTION
Switching help.qlik.com links to qlik.dev instead - to promote the dev-portal
