### PR TITLE
fix: Use strconv in custom float unmarshalling

### DIFF
--- a/float.go
+++ b/float.go
@@ -2,8 +2,7 @@ package enigma
 
 import (
 	"math"
-
-	"github.com/goccy/go-json"
+	"strconv"
 )
 
 //Float64 is an enigma-go equivalent of float64 which adds support for the Qlik Associative Engine specific way of marshalling and unmarshalling "Infinity", "-Infinity" and "NaN" as json strings.
@@ -15,12 +14,14 @@ func (value *Float64) UnmarshalJSON(arg []byte) error {
 	switch string(arg) {
 	case `"NaN"`:
 		*value = Float64(math.NaN())
-	case `"Infinity"`:
+	case `"Infinity"`, `"+Infinity"`:
 		*value = Float64(math.Inf(1))
 	case `"-Infinity"`:
 		*value = Float64(math.Inf(-1))
 	default:
-		return json.Unmarshal(arg, (*float64)(value))
+		float, err := strconv.ParseFloat(string(arg), 64)
+		*value = Float64(float)
+		return err
 	}
 	return nil
 }
@@ -35,5 +36,6 @@ func (value Float64) MarshalJSON() ([]byte, error) {
 	} else if math.IsInf(val, -1) {
 		return []byte(`"-Infinity"`), nil
 	}
-	return json.Marshal(float64(value))
+	str := strconv.FormatFloat(val, 'f', -1, 64)
+	return []byte(str), nil
 }


### PR DESCRIPTION
<!-- Please include a summary of your changes in this pull request. -->
This improve the performance of the custom float unmarshalling slightly compared to the goccy/go-json package.
On my machine:

(goccy)
```
> go test -bench=FloatUnmarshal -benchtime 60s
websocket: close 1000 (normal)goos: linux
goarch: amd64
pkg: github.com/qlik-oss/enigma-go/v3
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkFloatUnmarshal-12      304858903              237.8 ns/op
PASS
ok      github.com/qlik-oss/enigma-go/v3        96.879s
```

(strconv)
```
go test -bench=FloatUnmarshal -benchtime 60s
websocket: close 1000 (normal)goos: linux
goarch: amd64
pkg: github.com/qlik-oss/enigma-go/v3
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkFloatUnmarshal-12      343606368              209.1 ns/op
PASS
ok      github.com/qlik-oss/enigma-go/v3        93.551s
```

The improvements are slight but it might still be worth it if float-unmarshalling is a bottleneck.