### PR TITLE
Improve/json

### DIFF
--- a/float.go
+++ b/float.go
@@ -11,19 +11,15 @@ type Float64 float64
 
 // UnmarshalJSON implements the Unmarshaler interface for custom unmarshalling.
 func (value *Float64) UnmarshalJSON(arg []byte) error {
-	err := json.Unmarshal(arg, (*float64)(value))
-	if err != nil {
-		str := string(arg)
-		switch str {
-		case `"NaN"`:
-			*value = Float64(math.NaN())
-		case `"Infinity"`:
-			*value = Float64(math.Inf(1))
-		case `"-Infinity"`:
-			*value = Float64(math.Inf(-1))
-		default:
-			return err
-		}
+	switch string(arg) {
+	case `"NaN"`:
+		*value = Float64(math.NaN())
+	case `"Infinity"`:
+		*value = Float64(math.Inf(1))
+	case `"-Infinity"`:
+		*value = Float64(math.Inf(-1))
+	default:
+		return json.Unmarshal(arg, (*float64)(value))
 	}
 	return nil
 }

--- a/float.go
+++ b/float.go
@@ -2,8 +2,7 @@ package enigma
 
 import (
 	"math"
-
-	"github.com/goccy/go-json"
+	"strconv"
 )
 
 //Float64 is an enigma-go equivalent of float64 which adds support for the Qlik Associative Engine specific way of marshalling and unmarshalling "Infinity", "-Infinity" and "NaN" as json strings.
@@ -15,12 +14,14 @@ func (value *Float64) UnmarshalJSON(arg []byte) error {
 	switch string(arg) {
 	case `"NaN"`:
 		*value = Float64(math.NaN())
-	case `"Infinity"`:
+	case `"Infinity"`, `"+Infinity"`:
 		*value = Float64(math.Inf(1))
 	case `"-Infinity"`:
 		*value = Float64(math.Inf(-1))
 	default:
-		return json.Unmarshal(arg, (*float64)(value))
+		float, err := strconv.ParseFloat(string(arg), 64)
+		*value = Float64(float)
+		return err
 	}
 	return nil
 }
@@ -35,5 +36,6 @@ func (value Float64) MarshalJSON() ([]byte, error) {
 	} else if math.IsInf(val, -1) {
 		return []byte(`"-Infinity"`), nil
 	}
-	return json.Marshal(float64(value))
+	str := strconv.FormatFloat(val, 'f', -1, 64)
+	return []byte(str), nil
 }

--- a/float.go
+++ b/float.go
@@ -1,8 +1,9 @@
 package enigma
 
 import (
-	"encoding/json"
 	"math"
+
+	"github.com/goccy/go-json"
 )
 
 //Float64 is an enigma-go equivalent of float64 which adds support for the Qlik Associative Engine specific way of marshalling and unmarshalling "Infinity", "-Infinity" and "NaN" as json strings.

--- a/float_test.go
+++ b/float_test.go
@@ -2,9 +2,10 @@ package enigma
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFloatMarshalJSON(t *testing.T) {
@@ -112,4 +113,21 @@ func TestFloatCompoundMarshalJSON(t *testing.T) {
 	result, _ = json.Marshal(&cell)
 	assert.Equal(t, `{"qNum":"NaN"}`, string(result))
 
+}
+
+func BenchmarkFloatUnmarshal(b *testing.B) {
+	data := [][]byte{
+		[]byte(`"NaN"`),
+		[]byte(`"Infinity"`),
+		[]byte(`"-Infinity"`),
+		[]byte("1"),
+		[]byte("3.14"),
+	}
+	for i := 0; i < b.N; i++ {
+		var f Float64
+		err := json.Unmarshal(data[i%len(data)], &f)
+		if err != nil {
+			b.Error(err)
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/qlik-oss/enigma-go/v3
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/goccy/go-json v0.8.1
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.8.1 h1:4/Wjm0JIJaTDm8K1KcGrLHJoa8EsJ13YWeX+6Kfq6uI=
+github.com/goccy/go-json v0.8.1/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/remote_object.go
+++ b/remote_object.go
@@ -2,8 +2,9 @@ package enigma
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
+
+	"github.com/goccy/go-json"
 )
 
 type (

--- a/session.go
+++ b/session.go
@@ -3,10 +3,11 @@ package enigma
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type (

--- a/session_messages.go
+++ b/session_messages.go
@@ -2,8 +2,9 @@ package enigma
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
+
+	"github.com/goccy/go-json"
 )
 
 type (


### PR DESCRIPTION
* Swap json encoding/decoding from encoding/json to github.com/goccy/go-json
* Improved performance of Float64 unmarshal.

Greatly improves CPU utilization with a very minor increase of RAM usuage from "real life" meassurements.