### PR TITLE
refactor: fetch the engine spec from QCS instead

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -11,5 +11,5 @@ This folder contains a script for generating enigma-go based on your Qlik Cloud 
 
 
 ```bash
-ENGINE_VERSION=<version> ./schema/generate.sh
+./schema/generate.sh
 ```

--- a/schema/README.md
+++ b/schema/README.md
@@ -2,12 +2,12 @@
 
 This folder contains a script for generating enigma-go based on your Qlik Cloud tenant engine REST endpoint.
 
-> Note: Before running the script, make sure you have a valid Qlik Cloud tenant host and API key in your environment variables
-> ```bash
-> QCS_HOST=<tenant>.qlikcloud.com
-> QCS_API_KEY=<APIkey>
-> ```
-> - How to obtain an API key? [click here](https://qlik.dev/tutorials/generate-your-first-api-key)
+Note: Before running the script, make sure you have a valid Qlik Cloud tenant host and API key in your environment variables
+```bash
+QCS_HOST=<tenant>.qlikcloud.com
+QCS_API_KEY=<APIkey>
+```
+- How to obtain an API key? [click here](https://qlik.dev/tutorials/generate-your-first-api-key)
 
 
 ```bash

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,16 +1,15 @@
 # Schema Generator
 
-This folder contains a script for generating enigma-go based on a specific version of Qlik Associative Engine.
-The version to be used must be one of the published versions of the Qlik Associative Engine, see [here](https://hub.docker.com/r/qlikcore/engine/tags/).
+This folder contains a script for generating enigma-go based on your Qlik Cloud tenant engine REST endpoint.
 
-Please note that to be able to generate enigma-go you will need to accept the [EULA](https://core.qlik.com/eula/).
+> Note: Before running the script, make sure you have a valid Qlik Cloud tenant host and API key in your environment variables
+> ```bash
+> QCS_HOST=<tenant>.qlikcloud.com
+> QCS_API_KEY=<APIkey>
+> ```
+> - How to obtain an API key? [click here](https://qlik.dev/tutorials/generate-your-first-api-key)
+
 
 ```bash
-ACCEPT_EULA=<yes/no> ENGINE_VERSION=<version> ./schema/generate.sh
-```
-
-If a version is not specified the script will default to the latest published version.
-
-```bash
-ACCEPT_EULA=<yes/no> ./schema/generate.sh
+ENGINE_VERSION=<version> ./schema/generate.sh
 ```

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -2,36 +2,22 @@
 
 cd $(dirname "$0")
 
-# Check that the EULA has been accepted
-if [[ $ACCEPT_EULA != "yes" ]]; then
-    echo "The EULA for Qlik Associative Engine was not accepted. Please check the README for instructions on how to accept the EULA"
-    exit 1
+if [[ -z "${QCS_HOST}" ]] || [[ -z "${QCS_API_KEY}" ]]; then
+  echo "Please be sure to add a host (`QCS_HOST`) and apikey (`QCS_API_KEY`) as env. variable"
+  exit 1
 fi
 
-# Fetch latest published Qlik Associative Engine version on dockerhub if not specified
-if [ -z $ENGINE_VERSION ]; then
-    ENGINE_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/qlikcore/engine/tags/" | docker run -i stedolan/jq -r '."results"[0]["name"]' 2>/dev/null)
-    echo "Using latest Engine version $ENGINE_VERSION"
-fi
-
-# Retrieve the JSON-RPC API from Qlik Associative Engine REST API
-CONTAINER_ID=$(docker run -d -p 9077:9076 qlikcore/engine:$ENGINE_VERSION -S AcceptEULA=$ACCEPT_EULA)
-RETRIES=0
-while [[ $JSON_RPC_API == "" && $RETRIES != 10 ]]; do
-    JSON_RPC_API=$(curl -fs localhost:9077/openrpc)
-    sleep 2
-    RETRIES=$((RETRIES + 1 ))
-done
-docker kill $CONTAINER_ID
+OPEN_RPC_API=$(curl -fs -H "Authorization: Bearer $QCS_API_KEY" https://$QCS_HOST/api/engine/openrpc)
 
 # Generate enigma-go based on schema
-if [[ $JSON_RPC_API != "" ]]; then
-    echo "Generating enigma-go based on JSON-RPC API for Qlik Associative Engine version $ENGINE_VERSION"
-    echo "$JSON_RPC_API" > ./schema.json
+if [[ $OPEN_RPC_API != "" ]]; then
+    echo "$OPEN_RPC_API" > ./schema.json
+    ENGINE_VERSION=$(cat ./schema.json | jq -r '.info.version')
+    echo "Generating enigma-go based on OpenRPC API for Qlik Associative Engine version $ENGINE_VERSION"
     go run ./generate.go ./schema.json  ./schema-companion.json ../qix_generated.go enigma disable-enigma-import
     rm ./schema.json
     go fmt ../qix_generated.go > /dev/null
 else
-    echo "Failed to retrieve JSON-RPC API for Qlik Associative Engine version $ENGINE_VERSION"
+    echo "Failed to retrieve OpenRPC API for Qlik Associative Engine version $ENGINE_VERSION"
     exit 1
 fi


### PR DESCRIPTION
_Added to the doc:_
> Note: Before running the script, make sure you have a valid Qlik Cloud tenant host and API key in your environment variables
> ```bash
> QCS_HOST=<tenant>.qlikcloud.com
> QCS_API_KEY=<APIkey>
> ```
> - How to obtain an API key? [click here](https://qlik.dev/tutorials/generate-your-first-api-key)
