### PR TITLE
fix: Improve context handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ aliases:
       git diff --exit-code
 
   - &test
-      go test -v -race .
+      make test-unit
 
   - &spec_test |
       go test -v -race ./spec

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL := /bin/bash
 
+test-unit:
+	go test -count=1 -v -race .
+
 generate-schema:
 	./schema/generate.sh
 

--- a/default_dialer.go
+++ b/default_dialer.go
@@ -16,41 +16,29 @@ func setupDefaultDialer(dialer *Dialer) {
 		gorillaDialer := websocket.Dialer{
 			Proxy:           http.ProxyFromEnvironment, // Will pick the Proxy URL from the environment variables (HTTPS_PROXY).
 			TLSClientConfig: dialer.TLSClientConfig,
-			NetDial: func(network, addr string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, network, addr)
-			},
-			Jar: dialer.Jar,
+			Jar:             dialer.Jar,
 		}
 
 		// Run the actual websocket dialing (including the upgrade) in a goroutine so we can
 		// return if the context times out
-		chConn := make(chan *websocket.Conn, 1)
-		chErr := make(chan error, 1)
-		go func() {
-			conn, resp, err := gorillaDialer.Dial(url, httpHeader)
+		conn, resp, err := gorillaDialer.DialContext(ctx, url, httpHeader)
+		if err != nil {
 			if err == websocket.ErrBadHandshake {
-				chErr <- errors.Wrapf(err, "%d from ws server", resp.StatusCode)
-			} else if err != nil {
-				if strings.Contains(err.Error(), "Proxy Authentication") {
-					chErr <- fmt.Errorf("only proxies with http basic authentication are supported by enigma-go")
-				}
-				chErr <- err
-			} else {
-				select {
-				case <-ctx.Done():
-					conn.Close()
-				default:
-					chConn <- conn
+				err = errors.Wrapf(err, "%d from ws server", resp.StatusCode)
+			} else if strings.Contains(err.Error(), "Proxy Authentication") {
+				err = fmt.Errorf("only proxies with http basic authentication are supported by enigma-go")
+			} else if nerr, ok := err.(net.Error); ok {
+				// For some reason the net package times out a tiny bit before
+				// we get an error from ctx.Err(). To keep backwards compatability,
+				// we want to return a "context deadline exceeded" error in this case
+				// but it's not realiable to get it from ctx.Err. Therefore, we will
+				// assume that a network timeout error is equivalent.
+				if nerr.Timeout() {
+					err = context.DeadlineExceeded
 				}
 			}
-		}()
-		select {
-		case <-ctx.Done():
-			return nil, errors.Wrapf(ctx.Err(), "error connecting to ws server %s", url)
-		case err := <-chErr:
 			return nil, err
-		case ws := <-chConn:
-			return ws, nil
 		}
+		return conn, nil
 	}
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -79,9 +79,9 @@ func TestFullRpcScenario(t *testing.T) {
 			"id": 4,
 			"delta": false,
 			"error": {
-				"code": 123, 
-				"parameter": "param",  
-				"message":"mes"	
+				"code": 123,
+				"parameter": "param",
+				"message":"mes"
 			}
 		}`)
 

--- a/socket_edge_case_test.go
+++ b/socket_edge_case_test.go
@@ -289,35 +289,35 @@ func testTrace(m map[string]int) *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		GetConn: func(hostPort string) {
 			fmt.Println("Get Connection:", hostPort)
-			m["GetConn"] += 1
+			m["GetConn"]++
 		},
 		GotConn: func(info httptrace.GotConnInfo) {
 			fmt.Printf("Got Connection: %#v\n", info)
-			m["GotConn"] += 1
+			m["GotConn"]++
 		},
 		GotFirstResponseByte: func() {
 			fmt.Println("First byte!")
-			m["GotFirstResponseByte"] += 1
+			m["GotFirstResponseByte"]++
 		},
 		ConnectStart: func(network, addr string) {
 			fmt.Printf("Connect start: %s %s\n", network, addr)
-			m["ConnectStart"] += 1
+			m["ConnectStart"]++
 		},
 		ConnectDone: func(network, addr string, err error) {
 			fmt.Printf("Connect done: %s %s - err: %v\n", network, addr, err)
-			m["ConnectDone"] += 1
+			m["ConnectDone"]++
 		},
 		WroteHeaderField: func(key string, value []string) {
 			fmt.Printf("> %s: %s\n", key, strings.Join(value, ""))
-			m["WroteHeaderField"] += 1
+			m["WroteHeaderField"]++
 		},
 		WroteHeaders: func() {
 			fmt.Println("Wrote Headers")
-			m["WroteHeaders"] += 1
+			m["WroteHeaders"]++
 		},
 		WroteRequest: func(info httptrace.WroteRequestInfo) {
 			fmt.Println("Wrote Request - err:", info.Err)
-			m["WroteRequest"] += 1
+			m["WroteRequest"]++
 		},
 	}
 }


### PR DESCRIPTION
This simplifies how the default-dialer works by removing the functionality for context-cancelling on the enigma-end.
The package we're using for websockets and their dependencies (the standard libraries `net` and `net/http`) use contexts correctly.

The simplification also ensures that the context is passed correctly with `DialContext` which enables the use of `httptrace.ClientTrace` - a valuable tool for debugging.