### PR TITLE
chore: adding more golangs in ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ aliases:
 
   - &lint |
       go fmt ./...
-      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
-      ./bin/golangci-lint run
+      go get -u golang.org/x/lint/golint
+      golint -set_exit_status
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.
-      # Restore those files before proceeding to avoid side effect.
+      # Restore those files before proceeding to avoid saif effect.
       git checkout go.mod go.sum
       git diff --exit-code
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
 
   - &lint |
       go fmt ./...
-      go install -u golang.org/x/lint/golint
+      go install golang.org/x/lint/golint
       golint -set_exit_status
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ aliases:
   - &lint |
       LINT_VER=1.45.2
       go fmt ./...
-      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $LINT_VER || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$LINT_VER)
+      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
       ./bin/golangci-lint run
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ aliases:
       go build
 
   - &lint |
+      LINT_VERSION=1.45.2
       go fmt ./...
       @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
       ./bin/golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
       go build
 
   - &lint |
-      LINT_VERSION=1.45.2
+      LINT_VER=1.45.2
       go fmt ./...
       @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
       ./bin/golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.13
     environment:
       GOLANG_VERSION: "1.13"
     steps:
@@ -69,7 +69,7 @@ jobs:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.14
+      - image: cimg/go:1.14
     environment:
       GOLANG_VERSION: "1.14"
     steps:
@@ -91,7 +91,7 @@ jobs:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.15
+      - image: cimg/go:1.15
     environment:
       GOLANG_VERSION: "1.15"
     steps:
@@ -113,7 +113,7 @@ jobs:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.16
+      - image: cimg/go:1.16
     environment:
       GOLANG_VERSION: "1.16"
     steps:
@@ -130,11 +130,12 @@ jobs:
       - run: *spec_test
       - run: go test -v -race ./release/verval
       - run: *examples
+
   golang-1.17:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17
     environment:
       GOLANG_VERSION: "1.17"
     steps:
@@ -151,11 +152,12 @@ jobs:
       - run: *spec_test
       - run: go test -v -race ./release/verval
       - run: *examples
+
   golang-1.18:
     requires:
       - generate-schema
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     environment:
       GOLANG_VERSION: "1.18"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ aliases:
   - &lint |
       LINT_VER=1.45.2
       go fmt ./...
-      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
+      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $LINT_VER || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$LINT_VER)
       ./bin/golangci-lint run
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ aliases:
 
   - &lint |
       go fmt ./...
-      go get -u golang.org/x/lint/golint
-      golint -set_exit_status
+      @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
+      ./bin/golangci-lint run
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.
-      # Restore those files before proceeding to avoid saif effect.
+      # Restore those files before proceeding to avoid side effect.
       git checkout go.mod go.sum
       git diff --exit-code
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,48 @@ jobs:
       - run: *spec_test
       - run: go test -v -race ./release/verval
       - run: *examples
+  golang-1.17:
+    requires:
+      - generate-schema
+    docker:
+      - image: circleci/golang:1.17
+    environment:
+      GOLANG_VERSION: "1.17"
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-1.17{{ checksum "go.sum" }}
+      - run: *build
+      - save_cache:
+          key: dependency-cache-1.17{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run: *lint
+      - run: *test
+      - run: *spec_test
+      - run: go test -v -race ./release/verval
+      - run: *examples
+  golang-1.18:
+    requires:
+      - generate-schema
+    docker:
+      - image: circleci/golang:1.18
+    environment:
+      GOLANG_VERSION: "1.18"
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-1.18{{ checksum "go.sum" }}
+      - run: *build
+      - save_cache:
+          key: dependency-cache-1.18{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run: *lint
+      - run: *test
+      - run: *spec_test
+      - run: go test -v -race ./release/verval
+      - run: *examples
   
 
 workflows:
@@ -153,6 +195,16 @@ workflows:
               only:
                 - /v.*/
       - golang-1.16:
+          filters:
+            tags:
+              only:
+                - /v.*/
+      - golang-1.17:
+          filters:
+            tags:
+              only:
+                - /v.*/
+      - golang-1.18:
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
 
   - &lint |
       go fmt ./...
-      go get -u golang.org/x/lint/golint
+      go install -u golang.org/x/lint/golint
       golint -set_exit_status
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
       go build
 
   - &lint |
-      LINT_VER=1.45.2
+      LINT_VERSION=1.45.2
       go fmt ./...
       @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
       ./bin/golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ aliases:
 
   - &lint |
       go fmt ./...
-      go get -u -d golang.org/x/lint/golint
-      # go install golang.org/x/lint/golint
+      go get -u golang.org/x/lint/golint
+      go install golang.org/x/lint/golint
       golint -set_exit_status
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ aliases:
 
   - &lint |
       go fmt ./...
-      go install golang.org/x/lint/golint
+      go get -u -d golang.org/x/lint/golint
+      # go install golang.org/x/lint/golint
       golint -set_exit_status
       # go fmt and golint can alter go.mod and go.sum.
       # This will cause the git diff to give false negative.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ aliases:
       go build
 
   - &lint |
-      LINT_VERSION=1.45.2
       go fmt ./...
       @stat ./bin/golangci-lint > /dev/null && ./bin/golangci-lint --version | grep -q $(LINT_VER) || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(LINT_VER))
       ./bin/golangci-lint run


### PR DESCRIPTION
**Changes:**
- adds golang version `1.17` & `1.18` as target for e2e test
- uses the proper `cimg/go` convenience images from CCI

fixes https://github.com/qlik-oss/enigma-go/issues/208