### PR TITLE
Support suspend list

### DIFF
--- a/api-spec.json
+++ b/api-spec.json
@@ -539,6 +539,13 @@
           "items": {
             "type": "int"
           }
+        },
+        "Suspended": {
+          "description": "Suspended list of suspended object handles or nil",
+          "type": "slice",
+          "items": {
+            "type": "int"
+          }
         }
       }
     },

--- a/json_rpc_types.go
+++ b/json_rpc_types.go
@@ -28,8 +28,9 @@ type (
 	}
 
 	rpcStatusInfo struct {
-		Change []int `json:"change"`
-		Close  []int `json:"close"`
+		Change  []int `json:"change"`
+		Close   []int `json:"close"`
+		Suspend []int `json:"suspend"`
 	}
 
 	// socketOutput represents a request message sent to Qlik Associative Engine

--- a/session.go
+++ b/session.go
@@ -34,6 +34,8 @@ type (
 		Changed []int
 		// Closed  list of closed object handles or nil
 		Closed []int
+		// Suspended list of suspended object handles or nil
+		Suspended []int
 	}
 )
 
@@ -142,7 +144,7 @@ func (q *session) handleResponse(message []byte, receiveTimestamp time.Time) {
 		q.emitSessionMessage(rpcResponse.Method, rpcResponse.Params)
 	} else {
 		pendingCall := q.removePendingCall(rpcResponse.ID)
-		q.emitChangeLists(rpcResponse.Change, rpcResponse.Close, pendingCall == nil) // Emit this before marking the pending call as done to make sure it is there when the pending call returns
+		q.emitChangeLists(rpcResponse.Change, rpcResponse.Close, rpcResponse.Suspend, pendingCall == nil) // Emit this before marking the pending call as done to make sure it is there when the pending call returns
 		if pendingCall != nil {
 			pendingCall.Response = rpcResponse
 			pendingCall.receiveTimestamp = receiveTimestamp

--- a/session_change_lists.go
+++ b/session_change_lists.go
@@ -16,14 +16,14 @@ type (
 	}
 )
 
-func (e *sessionChangeLists) emitChangeLists(changed []int, closed []int, pushed bool) {
+func (e *sessionChangeLists) emitChangeLists(changed, closed, suspended []int, pushed bool) {
 	if len(changed) > 0 || len(closed) > 0 {
 		e.mutex.Lock()
 		defer e.mutex.Unlock()
 
 		for channelEntry := range e.channels {
 			if pushed || !channelEntry.pushedOnly {
-				channelEntry.channel <- ChangeLists{Changed: changed, Closed: closed}
+				channelEntry.channel <- ChangeLists{Changed: changed, Closed: closed, Suspended: suspended}
 			}
 		}
 	}

--- a/session_change_lists_test.go
+++ b/session_change_lists_test.go
@@ -1,8 +1,9 @@
 package enigma
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSessionChangeLists(t *testing.T) {
@@ -12,20 +13,23 @@ func TestSessionChangeLists(t *testing.T) {
 	pushedChangeListsChannel := s.ChangeListsChannel(true)
 
 	// Emit two lists
-	s.emitChangeLists([]int{1, 2}, []int{3, 4}, true)
-	s.emitChangeLists([]int{5, 6}, []int{7, 8}, false)
+	s.emitChangeLists([]int{1, 2}, []int{3, 4}, []int{9, 10}, true)
+	s.emitChangeLists([]int{5, 6}, []int{7, 8}, []int{11, 12}, false)
 
-	// Check that the lists appear as expecgted
+	// Check that the lists appear as expected
 	allData1 := <-allChangeListsChannel
 	allData2 := <-allChangeListsChannel
 	assert.Equal(t, 1, allData1.Changed[0])
 	assert.Equal(t, 3, allData1.Closed[0])
+	assert.Equal(t, 9, allData1.Suspended[0])
 	assert.Equal(t, 5, allData2.Changed[0])
 	assert.Equal(t, 7, allData2.Closed[0])
+	assert.Equal(t, 11, allData2.Suspended[0])
 
 	pushedData1 := <-pushedChangeListsChannel
 	assert.Equal(t, 1, pushedData1.Changed[0])
 	assert.Equal(t, 3, pushedData1.Closed[0])
+	assert.Equal(t, 9, pushedData1.Suspended[0])
 
 	// Check that the second non-pushed list doesn't appear
 	var nothingInChangePushedChangeList bool


### PR DESCRIPTION
Support `suspend` list as well in addition to existing `close` and `change` list.

Engine message example:

```
{"jsonrpc":"2.0","change":[1,2,3,4,5,6,7,8,9],"suspend":[1]}
```