### PR TITLE
chore: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,7 @@ aliases:
 
 version: 2
 jobs:
-  generate-schema:
-    docker:
-      - image: cimg/go:1.22
-    environment:
-      GOLANG_VERSION: "1.22"
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-1.22{{ checksum "go.sum" }}
-      - run: ./schema/generate.sh
-
   golang-1.22:
-    requires:
-      - generate-schema
     docker:
       - image: cimg/go:1.22
     environment:
@@ -68,8 +55,6 @@ jobs:
       - run: *examples
 
   golang-1.21:
-    requires:
-      - generate-schema
     docker:
       - image: cimg/go:1.21
     environment:
@@ -90,8 +75,6 @@ jobs:
       - run: *examples
 
   golang-1.20:
-    requires:
-      - generate-schema
     docker:
       - image: cimg/go:1.20
     environment:
@@ -115,7 +98,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - generate-schema
       - golang-1.22:
           filters:
             tags:

--- a/.github/workflows/release-enigma-go.yml
+++ b/.github/workflows/release-enigma-go.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: '^1.17'
       - name: Checkout enigma-go repo
-        uses: actions/checkout@v2  
+        uses: actions/checkout@v4
         with:
           repository: qlik-oss/enigma-go
           ref: master

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.21.0
+	golang.org/x/net v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02n
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -6,22 +6,13 @@ wget -q https://qlik.dev/specs/json-rpc/qix.json -O ./schema/engine-rpc.json
 git diff --exit-code origin/master -- ./schema/engine-rpc.json >/dev/null
 if [[ $? -ne 0 ]]; then
     ENGINE_VERSION=$(cat ./schema/engine-rpc.json | jq -r '.info.version')
-    MSG="Generating enigma-go based on OPEN-RPC API for Qlik Associative Engine version $ENGINE_VERSION"
-    echo $MSG
+    echo "Generating enigma-go based on OPEN-RPC API for Qlik Associative Engine version $ENGINE_VERSION"
     ## generate code
     go run ./schema/generate.go ./schema/engine-rpc.json ./schema/schema-companion.json ./qix_generated.go enigma disable-enigma-import
     ## format code
     go fmt ./qix_generated.go >/dev/null
     ## generate spec
     go run ./spec/generate.go
-    ## configure git
-    if [ "$CIRCLECI" == true ]; then
-        git config --global user.email "no-reply@example.com"
-        git config --global user.name "github-actions-bot"
-        git add .
-        git commit -a -m "chore: ${MSG}"
-        git push --set-upstream origin ${CIRCLE_BRANCH}
-    fi
 else
     echo "No changes to engine-rpc.json, nothing to do."
 fi


### PR DESCRIPTION
Bump gha dependency `checkout` to `v4` and go-dep `golang.org/x/net` to `v0.25.0`.

No more auto-commit on each commit through generate-schema.